### PR TITLE
don't set default collectorversion

### DIFF
--- a/argus/values.yaml
+++ b/argus/values.yaml
@@ -4,7 +4,6 @@ imageRepository: logicmonitor/argus
 imageTag: latest
 imagePullPolicy: Always
 collectorSize: small
-collectorVersion: 24200
 disableAlerting: false
 deleteDevices: false
 debug: false


### PR DESCRIPTION
we should allow the ability to rely on the collector image / api default instead of artificially setting a default in the values. 