### PR TITLE
Set fluentd logging level at system level from info to warn

### DIFF
--- a/lm-logs/templates/configmap.yaml
+++ b/lm-logs/templates/configmap.yaml
@@ -8,6 +8,10 @@ data:
   fluent.conf: |
     @include kubernetes.conf
 
+    <system>
+      log_level warn
+    </system>
+
     <label @FLUENT_LOG>
       <match fluent.**>
         @type null


### PR DESCRIPTION
Fluentd is generating too much logs from service and plugin. Setting default to warm which can be overrode at plugin level 