### PR TITLE
update ingress templates

### DIFF
--- a/lmotel/templates/_helpers.tpl
+++ b/lmotel/templates/_helpers.tpl
@@ -49,10 +49,3 @@ Selector labels
 app.kubernetes.io/name: {{ include "lmotel.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-{{- define "ingress.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
-{{- print "networking.k8s.io/v1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}

--- a/lmotel/templates/ingress-default.yaml
+++ b/lmotel/templates/ingress-default.yaml
@@ -1,5 +1,13 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: {{ template "ingress.apiVersion" . }}
+{{- $apiV1 := false -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $apiV1 = true -}}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ include "lmotel.fullname" . }}-http
@@ -25,6 +33,7 @@ spec:
       {{- with .Values.service }}
       http:
         paths:
+          {{- if $apiV1 }}
           - path: /rest/ingest
             pathType: Prefix
             backend:
@@ -39,6 +48,16 @@ spec:
                 name: {{.name}}
                 port:
                   number: {{.ports.healthcheck}}
+          {{- else }}
+          - path: /rest/ingest
+            backend:
+              serviceName: {{.name}}
+              servicePort: {{.ports.http}}
+          - path: /health
+            backend:
+              serviceName: {{.name}}
+              servicePort: {{.ports.healthcheck}}
+          {{- end }}
       {{- end }}
   tls:
     - hosts:

--- a/lmotel/templates/ingress-grpc.yaml
+++ b/lmotel/templates/ingress-grpc.yaml
@@ -1,5 +1,13 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: {{ template "ingress.apiVersion" . }}
+{{- $apiV1 := false -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $apiV1 = true -}}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ include "lmotel.fullname" . }}-grpc
@@ -27,6 +35,7 @@ spec:
       {{- with .Values.service }}
       http:
         paths:
+          {{- if $apiV1 }}
           - path: /
             pathType: Prefix
             backend:
@@ -34,6 +43,12 @@ spec:
                 name: {{.name}}
                 port:
                   number: {{.ports.grpc}}
+          {{- else }}
+          - path: /
+            backend:
+              serviceName: {{.name}}
+              servicePort: {{.ports.grpc}}
+          {{- end }}
       {{- end }}
   tls:
     - hosts:

--- a/releasemanager/templates/ingress.yaml
+++ b/releasemanager/templates/ingress.yaml
@@ -1,6 +1,14 @@
 {{- if .Values.ingress }}
 {{- if .Values.ingress.hosts }}
+{{- $apiV1 := false -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- $apiV1 = true -}}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ template "releasemanager.name" $ }}
@@ -15,10 +23,19 @@ spec:
   - host: {{ $host }}
     http:
       paths:
+        {{- if $apiV1 }}
+        - backend:
+            service:
+              name: {{ template "releasemanager.name" $ }}
+              port: 8080
+          path: /
+          pathType: Prefix
+        {{- else }}
         - backend:
             serviceName: {{ template "releasemanager.name" $ }}
             servicePort: 8080
           path: /
+        {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The various ingress yaml files present in this repo need some updates so they work with different versions of the Ingress API.  (They only work with specific versions) 

The `lmotel` ingress templates are setup to use either `networking.k8s.io/v1` or `networking.k8s.io/v1beta1`, but the paths sections of the ingress templates don't account for the differences in the yaml used with either API version.  So it looks like they would only actually work the `networking.k8s.io/v1` endpoint because the values they use are only expected with that version fo the API

Example difference between API versions:
`serviceName` -> `service.name`
`servicePort` -> `service.port.name` OR `service.port.name` (depending on the type of value)
https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
(Github PR for the change https://github.com/kubernetes/kubernetes/pull/89778)

Because of this I added the if/else to the path definition so the yaml used is based off the Ingress API version.

I removed the ingress API related lines from `lmotel/templates/_helpers.tpl` because they aren't needed with the updates made to `lmotel/templates/ingress-default.yaml` and `lmotel/templates/ingress-grpc.yaml`

The `releasemanager` ingress template has a similar problem with compatibility.  It though is pinned to using `extensions/v1beta1` and the yaml file formatting expected by older version of the Ingress API.  The change in this PR updates the ingress template to be compatible with the current GA Ingress API endpoint (`networking.k8s.io/v1`), so that this chart will work for those that have a Kuberneters 1.22 cluster. (which no longer supports the deprecated endpoints `networking.k8s.io/v1beta1` and `extensions/v1beta1`)