### PR TITLE
Fix indentation for env range

### DIFF
--- a/lm-logs/templates/deamonset.yaml
+++ b/lm-logs/templates/deamonset.yaml
@@ -25,8 +25,8 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
           {{- range $key, $val := .Values.env }}
-            - name: {{ $key }}
-              value: {{ $val | quote }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:


### PR DESCRIPTION
indentation is too far in which causes a YAML to JSON conversion error